### PR TITLE
added dockerfile to spawn dev enviroment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.12
+LABEL description="dev enviroment for embedding"
+ARG device=gpu
+RUN pip install pandas python-dotenv openai backoff faiss-${device}
+WORKDIR /embedding
+
+
+CMD ["bash"]


### PR DESCRIPTION
`docker build  . --buildarg device=cpu -t stoneye/dev:0`

Change cpu to gpu if you are on a gpu enabled device.

`docker run -v path/to/GPT_embedding:/GPT_embedding -it stoneye/dev:0`

This should activate a environment where you can run local python files:

` python main.py`

Since this mounts a local drive to the container, the .env file should also be brought into the container.